### PR TITLE
fix: バス発車時の表記タイミング修正

### DIFF
--- a/20_Source/BusNow/BusNow/ViewModels/BusScheduleViewModel.swift
+++ b/20_Source/BusNow/BusNow/ViewModels/BusScheduleViewModel.swift
@@ -175,7 +175,7 @@ class BusScheduleViewModel: ObservableObject {
             let currentTotalMinutes = currentHour * 60 + currentMinute
             let scheduledTotalMinutes = scheduledHour * 60 + scheduledMinute
             
-            return currentTotalMinutes > scheduledTotalMinutes
+            return currentTotalMinutes >= scheduledTotalMinutes // 発車時刻ちょうどでも発車済とする
         }
         
         return false

--- a/20_Source/BusNow/BusNow/Views/Schedule/BusScheduleView.swift
+++ b/20_Source/BusNow/BusNow/Views/Schedule/BusScheduleView.swift
@@ -271,7 +271,7 @@ struct BusScheduleRowView: View {
                                 .foregroundColor(.gray)
                         } else if isNextBus {
                             if let minutes = minutesUntil {
-                                Text(minutes <= 1 ? "まもなく" : "あと\(minutes)分")
+                                Text(minutes == 1 ? "まもなく" : "あと\(minutes)分")
                                     .font(.caption2)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.blue)


### PR DESCRIPTION
Fixes #3

## 概要
バス発車時刻の表記タイミングを名古屋市バスの実際の運行に合わせて修正しました。

## 変更内容

1. 「まもなく」表示: `minutes <= 1` → `minutes == 1` （発車1分前のみ）
2. 「発車済」判定: `>` 比較 → `>=` 比較 （発車時刻ちょうどでも発車済）

「あと○分」 → 「まもなく」 → 「発車済」の切り替えタイミングが正確に実行されるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)