### PR TITLE
Fix service type toggle initialization based on schedule data serviceId

### DIFF
--- a/20_Source/BusNow/BusNow/Services/SupabaseService.swift
+++ b/20_Source/BusNow/BusNow/Services/SupabaseService.swift
@@ -339,6 +339,7 @@ struct BusScheduleData {
     let routeName: String
     let destination: String
     let platform: String
+    let serviceId: String
     
     // RPC レスポンスから BusScheduleData への変換（表示用正規化適用）
     init(from rpcResponse: BusScheduleRPCResponse) {
@@ -347,6 +348,7 @@ struct BusScheduleData {
         self.routeName = rpcResponse.routeName.normalizedForDisplay()
         self.destination = rpcResponse.destination.normalizedForDisplay()
         self.platform = rpcResponse.platform
+        self.serviceId = rpcResponse.serviceId
     }
     
     // 時刻文字列から秒を削除するヘルパー関数
@@ -361,11 +363,12 @@ struct BusScheduleData {
     }
     
     // 既存のイニシャライザーも保持（テスト用）
-    init(departureTime: String, routeName: String, destination: String, platform: String) {
+    init(departureTime: String, routeName: String, destination: String, platform: String, serviceId: String = "平日") {
         self.departureTime = departureTime
         self.routeName = routeName
         self.destination = destination
         self.platform = platform
+        self.serviceId = serviceId
     }
 }
 

--- a/20_Source/BusNow/BusNow/ViewModels/BusScheduleViewModel.swift
+++ b/20_Source/BusNow/BusNow/ViewModels/BusScheduleViewModel.swift
@@ -75,6 +75,7 @@ class BusScheduleViewModel: ObservableObject {
                 date: targetDate
             )
             busSchedules = schedules
+            updateServiceTypeFromScheduleData() // 取得データに基づいてサービスタイプを更新
             updateNextBusIndex() // 次のバスのインデックスを更新
         } catch {
             errorMessage = "時刻表の取得に失敗しました: \(error.localizedDescription)"
@@ -196,6 +197,19 @@ class BusScheduleViewModel: ObservableObject {
         let newIndex = findNextBusIndex()
         if nextBusIndex != newIndex {
             nextBusIndex = newIndex
+        }
+    }
+    
+    // 取得したスケジュールデータに基づいてサービスタイプを更新
+    private func updateServiceTypeFromScheduleData() {
+        guard let firstSchedule = busSchedules.first else { return }
+        
+        // serviceIdが "平日" の場合は weekday、それ以外は holiday
+        let newServiceType: ServiceType = (firstSchedule.serviceId == "平日") ? .weekday : .holiday
+        
+        // 現在の選択と異なる場合のみ更新
+        if selectedServiceType != newServiceType {
+            selectedServiceType = newServiceType
         }
     }
     


### PR DESCRIPTION
- Add serviceId field to BusScheduleData struct to preserve service type information
- Update ViewModel to initialize toggle state from first schedule item's serviceId
- Set weekday button if serviceId is "平日", otherwise set weekend/holiday button
- Fixes issue where toggle always defaulted to weekday regardless of actual data

🤖 Generated with [Claude Code](https://claude.ai/code)