### PR TITLE
fix: change search screen title to indicate user input requirement

### DIFF
--- a/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
+++ b/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
@@ -11,7 +11,7 @@ struct StationSelectionView: View {
         ScrollView {
             VStack(spacing: 0) {
                 // Header
-                Text("バス停の選択")
+                Text("バス停を入力")
                     .font(.title2)
                     .fontWeight(.semibold)
                     .padding(.top, 60)


### PR DESCRIPTION
Changed title from 'バス停の選択' (Bus Stop Selection) to 'バス停を入力' (Input Bus Stops) to clearly indicate that users need to input station names themselves rather than selecting from predefined options.

Fixes #16

Generated with [Claude Code](https://claude.ai/code)