### PR TITLE
feat: バス停検索履歴クリア時の確認ダイアログを追加

### DIFF
--- a/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
+++ b/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
@@ -4,6 +4,7 @@ struct StationSelectionView: View {
     @StateObject private var viewModel = StationSelectionViewModel()
     @State private var departureStation = ""
     @State private var arrivalStation = ""
+    @State private var showingClearAlert = false
     
     var onStationsPaired: (StationPair) -> Void
     
@@ -120,7 +121,7 @@ struct StationSelectionView: View {
                             Spacer()
                             
                             Button("クリア") {
-                                viewModel.clearHistory()
+                                showingClearAlert = true
                             }
                             .font(.body)
                             .foregroundColor(.blue)
@@ -181,6 +182,14 @@ struct StationSelectionView: View {
         .background(Color(.systemGroupedBackground))
         .onAppear {
             loadSavedStations()
+        }
+        .alert("検索履歴をクリア", isPresented: $showingClearAlert) {
+            Button("キャンセル", role: .cancel) { }
+            Button("クリア", role: .destructive) {
+                viewModel.clearHistory()
+            }
+        } message: {
+            Text("検索履歴を削除しますか？この操作は取り消すことができません。")
         }
     }
     


### PR DESCRIPTION
Issue #20の改善要望を実装:バス停の検索履歴をクリアする際に確認ダイアログを表示する機能を追加しました。

## 変更内容

- StationSelectionViewに確認アラートの状態変数を追加
- クリアボタンをタップ時に確認ダイアログを表示
- 「キャンセル」と「クリア」の選択肢を提供
- クリア時に「この操作は取り消すことができません」の警告を表示

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)