### PR TITLE
Set XCode Language to Japanese

### DIFF
--- a/20_Source/BusNow/BusNow.xcodeproj/project.pbxproj
+++ b/20_Source/BusNow/BusNow.xcodeproj/project.pbxproj
@@ -210,11 +210,12 @@
 				};
 			};
 			buildConfigurationList = 854B80142E5B65BF0076D591 /* Build configuration list for PBXProject "BusNow" */;
-			developmentRegion = en;
+			developmentRegion = ja;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = 854B80102E5B65BF0076D591;
 			minimizedProjectReferenceProxies = 1;

--- a/20_Source/BusNow/BusNow/en.lproj/InfoPlist.strings
+++ b/20_Source/BusNow/BusNow/en.lproj/InfoPlist.strings
@@ -1,0 +1,12 @@
+/*
+  InfoPlist.strings
+  BusNow (English)
+
+  English localization for app metadata
+*/
+
+/* App Display Name */
+CFBundleDisplayName = "BusNow";
+
+/* App Name */
+CFBundleName = "BusNow";

--- a/20_Source/BusNow/BusNow/ja.lproj/InfoPlist.strings
+++ b/20_Source/BusNow/BusNow/ja.lproj/InfoPlist.strings
@@ -1,0 +1,12 @@
+/*
+  InfoPlist.strings
+  BusNow (Japanese)
+
+  Japanese localization for app metadata
+*/
+
+/* App Display Name */
+CFBundleDisplayName = "ばすみる";
+
+/* App Name */
+CFBundleName = "BusNow";


### PR DESCRIPTION
- プロジェクトのdevelopmentRegionをjaに変更
- knownRegionsに日本語(ja)を追加
- InfoPlist.stringsファイルを日本語版と英語版で作成
- App Storeでの表示が日本語になるように設定

この変更により、App Storeのインストール画面での言語表示が
英語から日本語に変更されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)