### PR TITLE
fix: 再試行リンクをボタンに変更

### DIFF
--- a/20_Source/BusNow/BusNow/Views/Schedule/BusScheduleView.swift
+++ b/20_Source/BusNow/BusNow/Views/Schedule/BusScheduleView.swift
@@ -226,10 +226,19 @@ struct BusScheduleView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 20)
             
-            Button("再試行") {
+            Button(action: {
                 viewModel.refreshSchedules()
+            }) {
+                Text("再試行")
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+                    .frame(minWidth: 120)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 24)
+                    .background(Color.blue)
+                    .cornerRadius(8)
             }
-            .foregroundColor(.blue)
             .padding(.top, 8)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
エラー表示画面の「再試行」をテキストリンクから
視覚的に分かりやすいボタンに変更しました。

- 白文字 + 青背景のボタンスタイルを適用
- パディングと角丸を追加して押しやすく改善
- 最小幅を設定してタップターゲットを確保

Fixes #32