### PR TITLE
feat: 検索入力画面にタブ領域を追加し「履歴」と「マップ」タブを実装

### DIFF
--- a/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
+++ b/20_Source/BusNow/BusNow/Views/StationSelectionView.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 
+// タブの種別を定義
+enum StationSelectionTab: String, CaseIterable {
+    case history = "履歴"
+    case map = "マップ"
+}
+
 struct StationSelectionView: View {
     @StateObject private var viewModel = StationSelectionViewModel()
     @State private var departureStation = ""
     @State private var arrivalStation = ""
     @State private var showingClearAlert = false
     @State private var showingSettings = false
+    @State private var selectedTab: StationSelectionTab = .history
 
     var onStationsPaired: (StationPair) -> Void
     
@@ -121,69 +128,110 @@ struct StationSelectionView: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 32)
                 
-                // Search History Section
-                if !viewModel.searchHistory.isEmpty {
-                    VStack(alignment: .leading, spacing: 16) {
-                        HStack {
-                            Text("検索履歴")
+                // Tab Section
+                VStack(spacing: 16) {
+                    // Tab Picker
+                    Picker("タブ", selection: $selectedTab) {
+                        ForEach(StationSelectionTab.allCases, id: \.self) { tab in
+                            Text(tab.rawValue).tag(tab)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 40)
+
+                    // Tab Content
+                    switch selectedTab {
+                    case .history:
+                        // Search History Tab Content
+                        if viewModel.searchHistory.isEmpty {
+                            // Empty State
+                            VStack(spacing: 12) {
+                                Image(systemName: "clock.arrow.circlepath")
+                                    .font(.system(size: 40))
+                                    .foregroundColor(.gray)
+                                Text("検索履歴がありません")
+                                    .font(.body)
+                                    .foregroundColor(.secondary)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 60)
+                        } else {
+                            VStack(alignment: .leading, spacing: 16) {
+                                HStack {
+                                    Text("検索履歴")
+                                        .font(.body)
+                                        .fontWeight(.medium)
+
+                                    Spacer()
+
+                                    Button("クリア") {
+                                        showingClearAlert = true
+                                    }
+                                    .font(.body)
+                                    .foregroundColor(.blue)
+                                }
+                                .padding(.horizontal, 20)
+
+                                List {
+                                    ForEach(viewModel.searchHistory, id: \.id) { history in
+                                        Button(action: {
+                                            departureStation = history.departureStation
+                                            arrivalStation = history.arrivalStation
+                                        }) {
+                                            HStack {
+                                                VStack(alignment: .leading, spacing: 4) {
+                                                    Text(history.displayName.normalizedForDisplay())
+                                                        .foregroundColor(.primary)
+
+                                                    Text(formatDate(history.createdAt))
+                                                        .font(.caption)
+                                                        .foregroundColor(.secondary)
+                                                }
+
+                                                Spacer()
+
+                                                Image(systemName: "chevron.right")
+                                                    .font(.caption)
+                                                    .foregroundColor(.gray)
+                                            }
+                                            .padding(.horizontal, 20)
+                                            .padding(.vertical, 12)
+                                        }
+                                        .listRowBackground(Color(.secondarySystemGroupedBackground))
+                                        .listRowSeparator(.visible, edges: .bottom)
+                                        .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0))
+                                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                            Button("削除") {
+                                                if let index = viewModel.searchHistory.firstIndex(where: { $0.id == history.id }) {
+                                                    viewModel.removeHistoryItem(at: index)
+                                                }
+                                            }
+                                            .tint(.red)
+                                        }
+                                    }
+                                }
+                                .listStyle(.plain)
+                                .scrollDisabled(true)
+                                .frame(height: CGFloat(viewModel.searchHistory.count * 60))
+                                .background(Color(.secondarySystemGroupedBackground))
+                                .cornerRadius(8)
+                                .padding(.horizontal, 20)
+                            }
+                        }
+
+                    case .map:
+                        // Map Tab Content
+                        VStack(spacing: 12) {
+                            Image(systemName: "map")
+                                .font(.system(size: 40))
+                                .foregroundColor(.gray)
+                            Text("マップ機能は準備中です")
                                 .font(.body)
-                                .fontWeight(.medium)
-                            
-                            Spacer()
-                            
-                            Button("クリア") {
-                                showingClearAlert = true
-                            }
-                            .font(.body)
-                            .foregroundColor(.blue)
+                                .foregroundColor(.secondary)
                         }
-                        .padding(.horizontal, 20)
-                        .padding(.top, 40)
-                        
-                        List {
-                            ForEach(viewModel.searchHistory, id: \.id) { history in
-                                Button(action: {
-                                    departureStation = history.departureStation
-                                    arrivalStation = history.arrivalStation
-                                }) {
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text(history.displayName.normalizedForDisplay())
-                                                .foregroundColor(.primary)
-                                            
-                                            Text(formatDate(history.createdAt))
-                                                .font(.caption)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        
-                                        Spacer()
-                                        
-                                        Image(systemName: "chevron.right")
-                                            .font(.caption)
-                                            .foregroundColor(.gray)
-                                    }
-                                    .padding(.horizontal, 20)
-                                    .padding(.vertical, 12)
-                                }
-                                .listRowBackground(Color(.secondarySystemGroupedBackground))
-                                .listRowSeparator(.visible, edges: .bottom)
-                                .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0))
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button("削除") {
-                                        if let index = viewModel.searchHistory.firstIndex(where: { $0.id == history.id }) {
-                                            viewModel.removeHistoryItem(at: index)
-                                        }
-                                    }
-                                    .tint(.red)
-                                }
-                            }
-                        }
-                        .listStyle(.plain)
-                        .scrollDisabled(true)
-                        .frame(height: CGFloat(viewModel.searchHistory.count * 60))
-                        .background(Color(.secondarySystemGroupedBackground))
-                        .cornerRadius(8)
-                        .padding(.horizontal, 20)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 60)
                     }
                 }
                 


### PR DESCRIPTION
Closes #37

## Summary
- `StationSelectionTab` enumを追加し、「履歴」と「マップ」タブを定義
- セグメントコントロールによるタブ切り替えUIを実装
- 検索履歴を「履歴」タブ内に移動
- 「マップ」タブにプレースホルダーを追加

## Test plan
- [ ] アプリを起動し、検索入力画面にタブが表示されることを確認
- [ ] 「履歴」タブで検索履歴が表示されることを確認
- [ ] 「マップ」タブでプレースホルダーが表示されることを確認
- [ ] 履歴が空の場合に空状態表示が出ることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Station selection now features a tabbed interface enabling quick switching between History and upcoming Map functionality.
  * Map tab displays a placeholder indicating the feature is coming soon.

* **Improvements**
  * Reorganized layout and enhanced styling to support the new tabbed navigation system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->